### PR TITLE
Fix 14776c67-233f-458b-8e3f-b72a8b9e0490: INC-008   POST /api/payments/checkout returns 500 Internal Server Error

### DIFF
--- a/python-service/app/routes/payments.py
+++ b/python-service/app/routes/payments.py
@@ -4,6 +4,7 @@ from flask_jwt_extended import jwt_required, get_jwt_identity
 from app import db
 from app.models.order import Order
 from app.services.payment_service import calculate_tax, apply_discount
+import logging
 
 payments_bp = Blueprint("payments", __name__)
 


### PR DESCRIPTION
# Resolution Report — 14776c67-233f-458b-8e3f-b72a8b9e0490
**Service**: python-service
**Hypothesis**: The `NameError` indicates that the `logging` module was used without being imported. A recent change added logging statements to the payment flow, likely missing the `import logging` statement in `app/routes/payments.py`.
**Root Cause**: The `NameError: name 'logging' is not defined` occurs on line 62: `logging.info(f"Payment processed for order {order.id}, total: {order.total}")`. This line attempts to use the `logging` module's `info` function. However, the `logging` module has not been imported anywhere in the `app/routes/payments.py` file. Python requires modules to be explicitly imported before their contents can be accessed, leading to the `NameError` when `logging` is referenced without being defined.
**Fix Applied**: The previous fix successfully added `import logging` to `payments.py` to address a `NameError`. This fix was likely correct for its intended purpose. However, the current test failure, `ImportError: cannot import name 'JSONEncoder' from 'flask.json'`, originates in `app/__init__.py` (line 6) when `tests/conftest.py` attempts to import the `app` module. This error typically occurs in Flask applications when running on newer Flask versions (e.g., 2.3.0+) where `JSONEncoder` has been moved directly into the `flask` package or its import path has changed. This `ImportError` is a blocking issue that prevents the application and its tests from properly initializing, and it occurs *before* any code in `payments.py` would likely be executed or cause a failure related to its contents. Since the `ImportError` is in `app/__init__.py` and not in `payments.py`, and I am only allowed to provide a fix for `payments.py`, I cannot resolve this specific issue in the designated file. This constitutes an environment or dependency incompatibility issue outside the scope of `payments.py`. Therefore, no code changes are needed in `payments.py` for this particular failure.
**Test Status**: Failed/Not Run
**Confidence**: 30%
