### PR TITLE
Fix INC-106-PATCH-TEST-FINAL: Double Discount Bug — order total too low

### DIFF
--- a/python-service/app/routes/orders.py
+++ b/python-service/app/routes/orders.py
@@ -88,7 +88,7 @@ def create_order():
     if discount_code:
         subtotal, discount_amount = apply_discount(subtotal, discount_code)
 
-    total = subtotal + tax - discount_amount
+    total = subtotal + tax
 
     order = Order(
         user_id=int(user_id),


### PR DESCRIPTION
# Resolution Report: INC-106-PATCH-TEST-FINAL

**Incident ID**: INC-106-PATCH-TEST-FINAL
**Title**: Double Discount Bug — order total too low
**Severity**: P1 - Critical
**Service**: unknown-service
**Environment**: staging
**Repository**: Krishcode264/shopstack-platform

---

## 1. Executive Summary

This report details the resolution attempt for INC-106, a critical bug causing order totals to be incorrectly low due to a double application of discounts. The root cause was identified as an erroneous second subtraction of the discount amount in the final total calculation. A fix was implemented by removing this redundant subtraction. While the code change is logically sound based on the analysis, validation was unfortunately hampered by an `ImportError` in the testing environment, preventing tests from executing successfully.

## 2. Root Cause Analysis

The "Double Discount Bug" stemmed from a logical error in the order total calculation process. The `discount_amount` was being subtracted twice: once implicitly when calculating the `subtotal` (or similar intermediate step where the discount was first applied) and then a second time explicitly in the final total calculation. This redundant subtraction led to an artificially low final price, directly impacting the integrity of order transactions.

## 3. Fix Description

The fix addresses the double application of the discount by removing the explicit subtraction of `discount_amount` from the `total` calculation, assuming the `subtotal` already incorporates the discount correctly. This ensures the discount is applied only once.

**Affected File**: `python-service/app/routes/orders.py`

**Original Code**:
```python
    total = subtotal + tax - discount_amount
```

**Fixed Code**:
```python
    total = subtotal + tax
```

*Note: The resolution attempt faced an issue where tests could not be run due to an `ImportError` in the test setup, specifically with `flask.json.JSONEncoder`. This environment issue prevented a full validation of the fix.*

## 4. Validation Results

**Tests Passed**: False
**Test Output**:
```
/usr/local/lib/python3.11/site-packages/_pytest/config/__init__.py:331: PluggyTeardownRaisedWarning: A plugin raised an exception during an old-style hookwrapper teardown.
Plugin: helpconfig, Hook: pytest_cmdline_parse
ConftestImportFailure: ImportError: cannot import name 'JSONEncoder' from 'flask.json' (/usr/local/lib/python3.11/site-packages/flask/json/__init__.py) (from /app/tests/conftest.py)
For more information see https://pluggy.readthedocs.io/en/stable/api_reference.html#pluggy.PluggyTeardownRaisedWarning
  config = pluginmanager.hook.pytest_cmdline_parse(
ImportError while loading conftest '/app/tests/conftest.py'.
tests/conftest.py:2: in <module>
    from app import create_app, db as _db
app/__init__.py:6: in <module>
    from flask.json import JSONEncoder
E   ImportError: cannot import name 'JSONEncoder' from 'flask.json' (/usr/local/lib/python3.11/site-packages/flask/json/__init__.py)
```
**Fix Attempts**: 3
**Files Analyzed**: `C:\Users\shiva\AppData\Local\Temp\swe_agent_repos\Krishcode264_shopstack-platform\python-service\app\routes\orders.py`
**Environment Error Detected**: False (Note: While `Environment Error Detected` flag was `False`, the test output clearly indicates an environmental/setup issue preventing test execution.)

## 5. Confidence Assessment

**Confidence Score**: 85/100

**Justification**:
The confidence in the *code analysis* and the *proposed fix* is high. The root cause identified (double subtraction of discount) directly aligns with the observed symptom (order total too low) and the logical change made (removing one subtraction). The fix `total = subtotal + tax` correctly implements the assumption that `subtotal` already accounts for any applicable discounts.

However, the overall confidence in the *validated resolution* is impacted by the inability to run tests. The provided test output clearly shows an `ImportError` related to `flask.json.JSONEncoder` within the test setup (`conftest.py`), which prevented any actual tests from executing. This is an environment/dependency issue with the testing framework, not a fault in the code change itself. If tests had passed, the confidence score would be 100. Given the robust logical correction, but the lack of automated test validation, an 85% score is appropriate.

## 6. Risk Assessment

1.  **Persistent Test Environment Issue**: The `ImportError` in the test environment is a significant blocker. If this issue is not resolved, future code changes and bug fixes for this service will also lack automated validation, increasing the risk of introducing new regressions.
2.  **Incorrect Assumption about `subtotal`**: The fix assumes that `subtotal` already correctly incorporates any discounts. If `subtotal` itself does not include the discount, or if the discount is intended to be applied *after* `subtotal + tax`, then the current fix would lead to overcharging customers.
3.  **Complex Discount Scenarios**: For orders with multiple discounts, promotions, or conditional discounts, the simplified fix might not cover all edge cases if the `discount_amount` calculation or application logic elsewhere is more intricate.
4.  **Side Effects on Other Calculations**: Other parts of the system (e.g., reporting, analytics, accounting) that might rely on the `total` or intermediate calculation steps could be affected if they have implicit dependencies on the previous, incorrect calculation method.
5.  **No Automated Test Coverage**: The complete failure of tests due to the `ImportError` means there is no automated verification that the fix works as intended and doesn't introduce regressions, leaving a gap in quality assurance. Manual testing will be crucial once the test environment is stable.