### PR TITLE
Fix #41: "POST /api/payments/checkout returns 500 Internal Server Error",

### DIFF
--- a/python-service/app/routes/payments.py
+++ b/python-service/app/routes/payments.py
@@ -1,5 +1,6 @@
 from flask import Blueprint, request, jsonify
 from flask_jwt_extended import jwt_required, get_jwt_identity
+import logging
 
 from app import db
 from app.models.order import Order


### PR DESCRIPTION
# Resolution Report — INC-GH-4094105559
**Service**: python-service
**Hypothesis**: The 'logging' module was used in 'app/routes/payments.py' without being imported, leading to a NameError. This aligns with the recent change of adding logging statements to the payment flow.
**Root Cause**: The `NameError: name 'logging' is not defined` occurred because the `logging` module was used on line 48: `logging.info(f"Payment processed for order {order.id}, total: {order.total}")` without being imported first. The provided code snippet lacks the necessary `import logging` statement at the top of the file, leading to the runtime error when the `checkout` function attempts to use the `logging.info` method.
**Fix Applied**: My previous fix involved adding `import logging` to `payments.py` to resolve a `NameError`. This fix was likely correct for the issue it addressed. However, the tests are now failing with an `ImportError: cannot import name 'JSONEncoder' from 'flask.json'` originating from `app/__init__.py` and `tests/conftest.py`. This indicates a new issue, likely a Flask version incompatibility with the import statement in `app/__init__.py`, which prevents the test suite from even loading correctly. Since the current failure is not located in `payments.py` and is outside the scope of the file I am permitted to modify, no further changes are needed for `payments.py` to address this specific `ImportError`. The previous change to import `logging` in `payments.py` should remain, as it addresses a distinct issue in that file.
**Test Status**: Failed/Not Run
**Confidence**: 45%


---
Closes #41