### PR TITLE
Fix: INC-10455643652

### DIFF
--- a/node-service/src/index.js
+++ b/node-service/src/index.js
@@ -11,7 +11,7 @@ const PORT = process.env.PORT || 3000;
 
 app.use(
   cors({
-    origin: "http://localhost:3000",
+    origin: ["http://localhost:3000", "http://localhost:5173"],
     credentials: true,
   })
 );


### PR DESCRIPTION
# Resolution Report — INC-10455643652
**Service**: unknown
**Hypothesis**: The Node.js service's CORS configuration is incorrectly set to only allow requests from 'http://localhost:3000'. This causes frontend requests from 'http://localhost:5173' to be blocked, requiring an update to the server's CORS policy to include the frontend's origin.
**Root Cause**: The root cause of the CORS error is the misconfiguration of the `cors` middleware in `node-service/src/index.js`. Specifically, line 14: `origin: "http://localhost:3000"` is explicitly setting the allowed origin for API requests to `http://localhost:3000`. However, the incident summary states that the frontend application is running on `http://localhost:5173` (Vite dev server). When the frontend at `http://localhost:5173` attempts to make an API call to the backend at `http://localhost:3000`, the browser sends an `Origin` header of `http://localhost:5173`. The backend's `cors` middleware then checks this origin against its configured allowed origin (`http://localhost:3000`). Since `http://localhost:5173` does not match, the middleware prevents the request, and the browser blocks it, leading to the 'Access-Control-Allow-Origin' header mismatch error.
**Fix Applied**: Added 'http://localhost:5173' to the list of allowed CORS origins. This permits requests from the frontend development server (Vite) which is running on port 5173. The service was previously configured to only allow 'http://localhost:3000', causing the 'Access-Control-Allow-Origin' header mismatch.
**Test Status**: Failed/Not Run
**Confidence**: 30%
